### PR TITLE
Add placeholder projects and improve portfolio components

### DIFF
--- a/ReactPortafolioProject/src/App.css
+++ b/ReactPortafolioProject/src/App.css
@@ -3,7 +3,9 @@
     padding: 0;
 }
 
-Header{
-    position: fixed;
-    width: 100%;
+header {
+  position: fixed;
+  width: 100%;
+  top: 0;
+  left: 0;
 }

--- a/ReactPortafolioProject/src/App.test.tsx
+++ b/ReactPortafolioProject/src/App.test.tsx
@@ -1,16 +1,8 @@
-import App from "./App";
-import{describe,expect,it}from"vitest";
+import { describe, it, expect } from 'vitest';
+import App from './App';
 
-describe("description", ()=>{
-it("description", ()=>{
-expect(function()).toBe(result)
-})
-})
-
-/**
- * describe("description", ()=>{
-it("description", ()=>{
-expect(function()).toBe(result)
-})
-})
- */
+describe('App', () => {
+  it('is defined', () => {
+    expect(App).toBeDefined();
+  });
+});

--- a/ReactPortafolioProject/src/App.tsx
+++ b/ReactPortafolioProject/src/App.tsx
@@ -1,25 +1,20 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
-import Navbar from './components/Navbar/Navbar'
-import Footer from './components/Footer/Footer'
-import LandingPage from './components/LandingPage/LandingPage'
-import Projects from './components/Projects/Projects'
-import ContactForm from './components/ContactForm/ContactForm'
+import './App.css';
+import Navbar from './components/Navbar/Navbar';
+import Footer from './components/Footer/Footer';
+import LandingPage from './components/LandingPage/LandingPage';
+import Projects from './components/Projects/Projects';
+import ContactForm from './components/ContactForm/ContactForm';
 
 function App() {
-
-
   return (
     <div>
-        <Navbar />
-        <LandingPage/>
-        <Projects/>
-        <ContactForm/>
-        <Footer/>
+      <Navbar />
+      <LandingPage />
+      <Projects />
+      <ContactForm />
+      <Footer />
     </div>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/ReactPortafolioProject/src/components/ContactForm/ContactForm.css
+++ b/ReactPortafolioProject/src/components/ContactForm/ContactForm.css
@@ -1,5 +1,15 @@
-.form{
-    height: 100vh;
-    width: 100%;
-    background-color: burlywood;
+.form {
+  min-height: 100vh;
+  width: 100%;
+  background-color: burlywood;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.form form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 300px;
 }

--- a/ReactPortafolioProject/src/components/ContactForm/ContactForm.tsx
+++ b/ReactPortafolioProject/src/components/ContactForm/ContactForm.tsx
@@ -3,12 +3,12 @@ import "./ContactForm.css";
 
 function ContactForm() {
     return (
-        <div className='form'>
+        <div className='form' id='contact'>
             <form>
                 <label htmlFor='name'></label>
-                <input id='name' type='text' placeholder='Name'></input>
+                <input id='name' type='text' placeholder='Name' />
                 <label htmlFor='email'></label>
-                <input id='email' type='email' placeholder='Email'></input>
+                <input id='email' type='email' placeholder='Email' />
                 <label htmlFor='type'></label>
                 <select id='type' name='type'>
                     <option value="hireMe">Freelance project proposal</option>
@@ -16,7 +16,7 @@ function ContactForm() {
                     <option value="other">Other</option>
                 </select>
                 <label htmlFor='comment'></label>
-                <textarea id='comment' placeholder='Your message' >Your message</textarea>
+                <textarea id='comment' placeholder='Your message'></textarea>
                 <button type='submit'>Submit</button>
             </form>
         </div>

--- a/ReactPortafolioProject/src/components/Navbar/Icons.ts
+++ b/ReactPortafolioProject/src/components/Navbar/Icons.ts
@@ -1,17 +1,10 @@
-import React, { useEffect, useRef } from "react";
-import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faEnvelope } from "@fortawesome/free-solid-svg-icons";
-import {
-  faGithub,
-  faLinkedin,
-  faMedium,
-  faStackOverflow,
-} from "@fortawesome/free-brands-svg-icons";
+import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import { faEnvelope } from '@fortawesome/free-solid-svg-icons';
+import { faGithub, faLinkedin, faStackOverflow } from '@fortawesome/free-brands-svg-icons';
 
-interface SocialIcon{
-  icon:IconDefinition;
-  url:string
+interface SocialIcon {
+  icon: IconDefinition;
+  url: string;
 }
 
 const Icons: SocialIcon[] = [

--- a/ReactPortafolioProject/src/components/Navbar/InnerLinks.ts
+++ b/ReactPortafolioProject/src/components/Navbar/InnerLinks.ts
@@ -1,19 +1,17 @@
-interface links{
-	
-	name:string
-	url:string
-
+interface Link {
+  name: string;
+  url: string;
 }
 
-const InnerLinks: links[]=[
-	{
-		name:"Projects",
-		url:""
-	},
-	{
-		name:"Contact me",
-		url:""
-	}
-]
+const InnerLinks: Link[] = [
+  {
+    name: 'Projects',
+    url: '#projects',
+  },
+  {
+    name: 'Contact me',
+    url: '#contact',
+  },
+];
 
-export default  InnerLinks;
+export default InnerLinks;

--- a/ReactPortafolioProject/src/components/Projects/Projects.css
+++ b/ReactPortafolioProject/src/components/Projects/Projects.css
@@ -1,5 +1,11 @@
-.projects{
-    height: 100vh;
-    width: 100%;
-    background-color: aquamarine;
-    }
+.projects {
+  min-height: 100vh;
+  width: 100%;
+  background-color: aquamarine;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 40px 0;
+}

--- a/ReactPortafolioProject/src/components/Projects/Projects.tsx
+++ b/ReactPortafolioProject/src/components/Projects/Projects.tsx
@@ -1,7 +1,7 @@
-import React, {useEffect, useState} from 'react';
-import"./Projects.css";
-import fetchProjectData, {Project} from "./ProjectsData.ts";
-import Card from "./cards/Card.tsx"
+import React, { useEffect, useState } from 'react';
+import './Projects.css';
+import fetchProjectData, { Project } from './ProjectsData';
+import Card from './cards/Card';
 
 function Projects() {
     const [projects, setProjects] = useState<Project[]>([]);
@@ -12,19 +12,19 @@ function Projects() {
             setProjects(data);
         }
 
-        fetchData();
+        void fetchData();
     }, []);
 
     return (
-        <div className='projects'>
-            {/*projects.map((project, index) => (
+        <div className='projects' id='projects'>
+            {projects.map((project, index) => (
                 <Card
                     key={index}
                     title={project.title}
                     body={project.body}
                     photo={project.photo}
                 />
-            ))*/}
+            ))}
         </div>
     );
 }

--- a/ReactPortafolioProject/src/components/Projects/ProjectsData.ts
+++ b/ReactPortafolioProject/src/components/Projects/ProjectsData.ts
@@ -1,48 +1,46 @@
 import axios from 'axios';
-import * as fs from 'fs';
-import Projects from "./Projects.tsx";
 
 export interface Project {
-    title: string,
-    body: string,
-    photo: string
-}
-async function getReadmeContent(repository: string): Promise<string> {
-    const url = `https://api.github.com/repos/SETA1609/${repository}/readme`;
-
-    try {
-        const response = await axios.get(url);
-        const readmeData = response.data;
-        const readmeContent = Buffer.from(readmeData.content, 'base64').toString('utf-8');
-        return readmeContent;
-    } catch (error) {
-        console.error(`Error fetching README for ${repository}: ${error.message}`);
-        return '';
-    }
+  title: string;
+  body: string;
+  photo: string;
 }
 
-async function fetchProjectData(): Promise<Project[]>  {
-    const projects: Project[] = [
-        {
-            title: "Lotto-3000",
-            body: await getReadmeContent("LottoAufgabe"),
-            photo: ""
-        },
-        {
-            title: "Shee.app",
-            body: await getReadmeContent("vag"),
-            photo: ""
-        },
-        {
-            title: "AW-Endprojeckt",
-            body: await getReadmeContent("End-Projekt-AW"),
-            photo: ""
-        },
-        {
-            title: "Transilvania",
-            body: await getReadmeContent("transilvania"),
-            photo: ""
-        }
-    ];
+// Placeholder repository URLs. Replace with your own projects.
+const repos = [
+  'https://github.com/SETA1609/LottoAufgabe',
+  'https://github.com/SETA1609/vag',
+  'https://github.com/SETA1609/End-Projekt-AW',
+];
+
+interface RepoResponse {
+  name: string;
+  description: string | null;
+  owner?: { avatar_url?: string };
 }
-export default fetchProjectData;
+
+async function fetchRepo(repoUrl: string): Promise<Project> {
+  const path = repoUrl.replace('https://github.com/', '');
+  const [owner, repo] = path.split('/');
+
+  try {
+    const { data } = await axios.get<RepoResponse>(`https://api.github.com/repos/${owner}/${repo}`);
+    return {
+      title: data.name,
+      body: data.description ?? 'No description available.',
+      photo: data.owner?.avatar_url ?? 'https://via.placeholder.com/300x200',
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Error fetching repository ${repoUrl}: ${message}`);
+    return {
+      title: repo,
+      body: 'Unable to load repository details.',
+      photo: 'https://via.placeholder.com/300x200',
+    };
+  }
+}
+
+export default async function fetchProjectData(): Promise<Project[]> {
+  return Promise.all(repos.map(fetchRepo));
+}

--- a/ReactPortafolioProject/src/components/Projects/cards/Card.css
+++ b/ReactPortafolioProject/src/components/Projects/cards/Card.css
@@ -1,0 +1,23 @@
+.card {
+  background-color: white;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 16px;
+  width: 300px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.card-image img {
+  width: 100%;
+  height: auto;
+  border-radius: 4px;
+  margin-bottom: 8px;
+}
+
+.card h3 {
+  margin: 0 0 8px;
+}
+
+.card p {
+  margin: 0;
+}

--- a/ReactPortafolioProject/src/components/Projects/cards/Card.tsx
+++ b/ReactPortafolioProject/src/components/Projects/cards/Card.tsx
@@ -1,13 +1,24 @@
 import React from 'react';
-import "./Card.css";
+import './Card.css';
 
+interface CardProps {
+  title: string;
+  body: string;
+  photo: string;
+}
 
-function Card(props) {
-    return (
-        <div>
-
+function Card({ title, body, photo }: CardProps) {
+  return (
+    <div className="card">
+      {photo && (
+        <div className="card-image">
+          <img src={photo} alt={title} />
         </div>
-    );
+      )}
+      <h3>{title}</h3>
+      <p>{body}</p>
+    </div>
+  );
 }
 
 export default Card;

--- a/ReactPortafolioProject/src/context/LanguageContext.tsx
+++ b/ReactPortafolioProject/src/context/LanguageContext.tsx
@@ -1,1 +1,29 @@
-const []
+import React, { createContext, useContext, useState } from 'react';
+
+type Language = 'en' | 'es';
+
+const LanguageContext = createContext<Language>('en');
+const LanguageUpdateContext = createContext<((lang: Language) => void) | undefined>(undefined);
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useLanguage = (): Language => useContext(LanguageContext);
+// eslint-disable-next-line react-refresh/only-export-components
+export const useSetLanguage = () => {
+  const setLanguage = useContext(LanguageUpdateContext);
+  if (!setLanguage) {
+    throw new Error('useSetLanguage must be used within a LanguageProvider');
+  }
+  return setLanguage;
+};
+
+export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [language, setLanguage] = useState<Language>('en');
+
+  return (
+    <LanguageContext.Provider value={language}>
+      <LanguageUpdateContext.Provider value={setLanguage}>
+        {children}
+      </LanguageUpdateContext.Provider>
+    </LanguageContext.Provider>
+  );
+};

--- a/ReactPortafolioProject/src/context/ThemeContext.tsx
+++ b/ReactPortafolioProject/src/context/ThemeContext.tsx
@@ -3,22 +3,37 @@ import React, { useState, useContext } from 'react';
 type ThemeUpdateFunction = () => void;
 const ThemeContext = React.createContext<boolean>(true);
 const ThemeUpdateContext = React.createContext<ThemeUpdateFunction | undefined>(undefined);
+
 interface ThemeProviderProps {
-    children: React.ReactNode;
+  children: React.ReactNode;
 }
+
 export function ThemeProvider({ children }: ThemeProviderProps) {
-    const [isDarkTheme, setDarkTheme] = useState<boolean>(true);
-    function toggleTheme() {
-        setDarkTheme(prevDarkTheme => !prevDarkTheme)
-    }
+  const [isDarkTheme, setDarkTheme] = useState<boolean>(true);
+  function toggleTheme() {
+    setDarkTheme(prevDarkTheme => !prevDarkTheme);
+  }
 
-    return (
-        <ThemeContext.Provider value={isDarkTheme}>
-            <ThemeUpdateContext.Provider value={toggleTheme}>
-                {children}
-            </ThemeUpdateContext.Provider>
+  return (
+    <ThemeContext.Provider value={isDarkTheme}>
+      <ThemeUpdateContext.Provider value={toggleTheme}>
+        {children}
+      </ThemeUpdateContext.Provider>
+    </ThemeContext.Provider>
+  );
+}
 
-        </ThemeContext.Provider>
-    )
+// eslint-disable-next-line react-refresh/only-export-components
+export function useTheme(): boolean {
+  return useContext(ThemeContext);
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useThemeUpdate(): ThemeUpdateFunction {
+  const context = useContext(ThemeUpdateContext);
+  if (!context) {
+    throw new Error('useThemeUpdate must be used within a ThemeProvider');
+  }
+  return context;
 }
 


### PR DESCRIPTION
## Summary
- Implement Project card component and placeholder project data
- Render project cards dynamically and anchor navigation to Projects and Contact sections
- Add basic contexts and style adjustments across portfolio
- Fetch project data from GitHub repositories using placeholder URLs

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b509f3ed788332b6c85c383123eb68