### PR TITLE
Add theme-aware styles, German translations, and card layering

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -8,4 +8,5 @@ header {
   width: 100%;
   top: 0;
   left: 0;
+  z-index: 10;
 }

--- a/src/components/ContactForm/ContactForm.css
+++ b/src/components/ContactForm/ContactForm.css
@@ -1,7 +1,8 @@
 .form {
   min-height: 100vh;
   width: 100%;
-  background-color: burlywood;
+  background-color: var(--contact-bg);
+  color: var(--text-color);
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -1,5 +1,5 @@
-footer{
-background-color: black;
-color: beige;
-height: 50px;
+footer {
+  background-color: var(--footer-bg);
+  color: var(--footer-color);
+  height: 50px;
 }

--- a/src/components/LandingPage/LandingPage.css
+++ b/src/components/LandingPage/LandingPage.css
@@ -1,7 +1,8 @@
+
 .landingPage {
     height: 100vh;
     width: 100%;
-    background-color: blueviolet;
+    background-color: var(--landing-bg);
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -21,14 +22,14 @@
     width: 250px;
 }
 
-p {
-    color: white;
+.landingPage p {
+    color: var(--text-color);
     font-size: 24px;
     margin-bottom: 10px;
 }
 
-h1 {
-    color: white;
+.landingPage h1 {
+    color: var(--text-color);
     font-size: 36px;
     text-align: center;
     max-width: 50%;

--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -1,7 +1,8 @@
 header {
-    background-color: black;
-    color: azure;
+    background-color: var(--navbar-bg);
+    color: var(--navbar-color);
     height: 50px;
+    z-index: 10;
 }
 
 .navbar {
@@ -30,7 +31,7 @@ header {
     display: block;
     padding: 10px;
     text-decoration: none;
-    color: white;
+    color: var(--navbar-color);
 }
 
 .links button {
@@ -41,7 +42,7 @@ header {
 
 
 a svg {
-    fill: white;
+    fill: var(--navbar-color);
     height: 15px;
     width: 15px;
 }

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -5,14 +5,16 @@ import InnerLinks from './InnerLinks';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
 import { useThemeUpdate } from '../../context/ThemeContext';
-import { useLanguage, useSetLanguage } from '../../context/LanguageContext';
+import { useLanguage, useSetLanguage, Language } from '../../context/LanguageContext';
+
+const languages: Language[] = ['en', 'es', 'de'];
 
 function Navbar() {
   const { t } = useTranslation();
   const toggleTheme = useThemeUpdate();
   const language = useLanguage();
   const setLanguage = useSetLanguage();
-  const nextLang = language === 'en' ? 'es' : 'en';
+  const nextLang = languages[(languages.indexOf(language) + 1) % languages.length];
 
   return (
     <header>
@@ -36,7 +38,7 @@ function Navbar() {
             <button onClick={toggleTheme}>{t('nav.toggleTheme')}</button>
           </li>
           <li>
-            <button onClick={() => setLanguage(nextLang)}>{t('nav.toggleLanguage')}</button>
+            <button onClick={() => setLanguage(nextLang)}>{t(`nav.language.${nextLang}`)}</button>
           </li>
         </ul>
       </nav>

--- a/src/components/Projects/Projects.css
+++ b/src/components/Projects/Projects.css
@@ -1,6 +1,12 @@
+
 .projects {
   min-height: 100vh;
   width: 100%;
-  background-color: aquamarine;
+  background-color: var(--projects-bg);
   padding: 40px 0;
+}
+
+.card {
+  position: relative;
+  z-index: 0;
 }

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import i18n from '../i18n';
 
-type Language = 'en' | 'es';
+export type Language = 'en' | 'es' | 'de';
 
 const LanguageContext = createContext<Language>('en');
 const LanguageUpdateContext = createContext<((lang: Language) => void) | undefined>(undefined);

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,61 +1,13 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
+import enTranslation from './locales/en/translation.json';
+import esTranslation from './locales/es/translation.json';
+import deTranslation from './locales/de/translation.json';
 
 const resources = {
-  en: {
-    translation: {
-      greeting: "Hi, I'm Sebastian!",
-      description: 'A fullstack developer specialized in Springboot, React, Angular and Django',
-      nav: {
-        projects: 'Projects',
-        contact: 'Contact me',
-        toggleTheme: 'Toggle Theme',
-        toggleLanguage: 'ES'
-      },
-      card: {
-        readMore: 'Read More'
-      },
-      contact: {
-        name: 'Name',
-        email: 'Email',
-        type: {
-          hireMe: 'Freelance project proposal',
-          openSource: 'Open source consultancy session',
-          other: 'Other'
-        },
-        message: 'Your message',
-        submit: 'Submit'
-      },
-      footer: 'footer'
-    }
-  },
-  es: {
-    translation: {
-      greeting: 'Hola, soy Sebastian!',
-      description: 'Un desarrollador fullstack especializado en Springboot, React, Angular y Django',
-      nav: {
-        projects: 'Proyectos',
-        contact: 'Contáctame',
-        toggleTheme: 'Cambiar tema',
-        toggleLanguage: 'EN'
-      },
-      card: {
-        readMore: 'Leer más'
-      },
-      contact: {
-        name: 'Nombre',
-        email: 'Correo',
-        type: {
-          hireMe: 'Propuesta de proyecto freelance',
-          openSource: 'Sesión de consultoría de código abierto',
-          other: 'Otro'
-        },
-        message: 'Tu mensaje',
-        submit: 'Enviar'
-      },
-      footer: 'pie de página'
-    }
-  }
+  en: { translation: enTranslation },
+  es: { translation: esTranslation },
+  de: { translation: deTranslation }
 };
 
 i18n.use(initReactI18next).init({

--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,25 @@
 body.light {
+  --text-color: #000000;
+  --landing-bg: #dcd0ff;
+  --projects-bg: #a0ffe6;
+  --contact-bg: #ffe4c4;
+  --navbar-bg: #f0f0f0;
+  --navbar-color: #000000;
+  --footer-bg: #f0f0f0;
+  --footer-color: #000000;
   background-color: #ffffff;
-  color: #000000;
+  color: var(--text-color);
 }
 
 body.dark {
+  --text-color: #ffffff;
+  --landing-bg: #4b0082;
+  --projects-bg: #006d6d;
+  --contact-bg: #8b4513;
+  --navbar-bg: #000000;
+  --navbar-color: #ffffff;
+  --footer-bg: #000000;
+  --footer-color: #ffffff;
   background-color: #000000;
-  color: #ffffff;
+  color: var(--text-color);
 }

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1,0 +1,29 @@
+{
+  "greeting": "Hallo, ich bin Sebastian!",
+  "description": "Ein Fullstack-Entwickler spezialisiert auf Springboot, React, Angular und Django",
+  "nav": {
+    "projects": "Projekte",
+    "contact": "Kontakt",
+    "toggleTheme": "Theme wechseln",
+    "language": {
+      "en": "EN",
+      "es": "ES",
+      "de": "DE"
+    }
+  },
+  "card": {
+    "readMore": "Mehr erfahren"
+  },
+  "contact": {
+    "name": "Name",
+    "email": "E-Mail",
+    "type": {
+      "hireMe": "Freelance-Projektvorschlag",
+      "openSource": "Open-Source-Beratung",
+      "other": "Andere"
+    },
+    "message": "Deine Nachricht",
+    "submit": "Senden"
+  },
+  "footer": "Fußzeile"
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,0 +1,29 @@
+{
+  "greeting": "Hi, I'm Sebastian!",
+  "description": "A fullstack developer specialized in Springboot, React, Angular and Django",
+  "nav": {
+    "projects": "Projects",
+    "contact": "Contact me",
+    "toggleTheme": "Toggle Theme",
+    "language": {
+      "en": "EN",
+      "es": "ES",
+      "de": "DE"
+    }
+  },
+  "card": {
+    "readMore": "Read More"
+  },
+  "contact": {
+    "name": "Name",
+    "email": "Email",
+    "type": {
+      "hireMe": "Freelance project proposal",
+      "openSource": "Open source consultancy session",
+      "other": "Other"
+    },
+    "message": "Your message",
+    "submit": "Submit"
+  },
+  "footer": "footer"
+}

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1,0 +1,29 @@
+{
+  "greeting": "Hola, soy Sebastian!",
+  "description": "Un desarrollador fullstack especializado en Springboot, React, Angular y Django",
+  "nav": {
+    "projects": "Proyectos",
+    "contact": "Contáctame",
+    "toggleTheme": "Cambiar tema",
+    "language": {
+      "en": "EN",
+      "es": "ES",
+      "de": "DE"
+    }
+  },
+  "card": {
+    "readMore": "Leer más"
+  },
+  "contact": {
+    "name": "Nombre",
+    "email": "Correo",
+    "type": {
+      "hireMe": "Propuesta de proyecto freelance",
+      "openSource": "Sesión de consultoría de código abierto",
+      "other": "Otro"
+    },
+    "message": "Tu mensaje",
+    "submit": "Enviar"
+  },
+  "footer": "pie de página"
+}


### PR DESCRIPTION
## Summary
- add JSON-based i18n resources and German language
- cycle through three languages in navbar
- introduce theme variables for section colors and adjust card z-index

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b8eaae688332a259e921e3cd2bc3