### PR TITLE
Improve language selector and project layout

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,7 +1,10 @@
+import React from 'react';
 import { render } from '@testing-library/react';
 import App from './App';
 import { ThemeProvider } from './context/ThemeContext';
 import { LanguageProvider } from './context/LanguageContext';
+
+React;
 
 jest.mock('./components/Projects/Projects', () => ({
   __esModule: true,

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import App from './App';
 import { ThemeProvider } from './context/ThemeContext';

--- a/src/components/ContactForm/ContactForm.tsx
+++ b/src/components/ContactForm/ContactForm.tsx
@@ -36,6 +36,7 @@ const ContactForm: React.FC = () => {
       if (success) {
         setToastMessage(`Thank you ${form.name}, your message was sent successfully!`);
         setToastType('success');
+        setForm({ name: '', email: '', type: 'hireMe', message: '' });
       } else {
         setToastMessage('There was an error sending your message.');
         setToastType('danger');
@@ -74,7 +75,7 @@ const ContactForm: React.FC = () => {
           {t('contact.submit')}
         </button>
       </form>
-      <div className='position-fixed bottom-0 end-0 p-3' style={{ zIndex: 11 }}>
+      <div className='position-fixed top-0 start-50 translate-middle-x p-3' style={{ zIndex: 11 }}>
         <div ref={toastRef} className={`toast align-items-center text-bg-${toastType} border-0`} role='alert' aria-live='assertive' aria-atomic='true'>
           <div className='d-flex'>
             <div className='toast-body'>{toastMessage}</div>

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -8,6 +8,11 @@ import { useLanguage, useSetLanguage, Language } from '../../context/LanguageCon
 import './Navbar.css';
 
 const languages: Language[] = ['en', 'es', 'de'];
+const languageFlags: Record<Language, string> = {
+  en: '🇺🇸',
+  es: '🇪🇸',
+  de: '🇩🇪'
+};
 
 const Navbar: React.FC = () => {
   const { t } = useTranslation();
@@ -92,13 +97,13 @@ const Navbar: React.FC = () => {
                 data-bs-toggle="dropdown"
                 aria-expanded="false"
               >
-                {t(`nav.language.${language}`)}
+                {languageFlags[language]}
               </button>
               <ul className="dropdown-menu dropdown-menu-end">
                 {languages.map(lang => (
                   <li key={lang}>
                     <button className="dropdown-item text-center" onClick={() => setLanguage(lang)}>
-                      {t(`nav.language.${lang}`)}
+                      {languageFlags[lang]}
                     </button>
                   </li>
                 ))}

--- a/src/components/Projects/Projects.test.tsx
+++ b/src/components/Projects/Projects.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import Projects from './Projects';
 import fetchProjectData from './ProjectsData';

--- a/src/components/Projects/Projects.test.tsx
+++ b/src/components/Projects/Projects.test.tsx
@@ -1,6 +1,9 @@
+import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import Projects from './Projects';
 import fetchProjectData from './ProjectsData';
+
+React;
 
 jest.mock('./ProjectsData');
 jest.mock('react-i18next', () => ({

--- a/src/components/Projects/Projects.tsx
+++ b/src/components/Projects/Projects.tsx
@@ -22,7 +22,8 @@ const Projects: React.FC = () => {
     }, []);
 
     return (
-        <div className='projects container text-center' id='projects'>
+        <section className='projects text-center' id='projects'>
+        <div className='container'>
         <div className='fw-bold fs-1 pb-2'>{t('project.title')}</div>
             {loading ? (
                 <div className='d-flex justify-content-center py-5'>
@@ -43,6 +44,7 @@ const Projects: React.FC = () => {
             </div>
             )}
         </div>
+        </section>
     );
 };
 export default Projects;

--- a/src/components/Projects/ProjectsData.ts
+++ b/src/components/Projects/ProjectsData.ts
@@ -1,4 +1,8 @@
 import axios from 'axios';
+import lottoImg from '../../assets/projects/lotto.jpg';
+import vagImg from '../../assets/projects/vag.jpg';
+import finalImg from '../../assets/projects/final-project.jpg';
+import portafolioImg from '../../assets/projects/portafolio.jpg';
 
 export interface Project {
   title: string;
@@ -15,22 +19,28 @@ const repos = [
   'https://github.com/SETA1609/ReactPortafolioProject',
 ];
 
+const repoImages: Record<string, string> = {
+  LottoAufgabe: lottoImg,
+  vag: vagImg,
+  'End-Projekt-AW': finalImg,
+  ReactPortafolioProject: portafolioImg
+};
+
 interface RepoResponse {
   name: string;
   description: string | null;
-  owner?: { avatar_url?: string };
 }
 
 async function fetchRepo(repoUrl: string): Promise<Project> {
   const path = repoUrl.replace('https://github.com/', '');
-  const [owner, repo] = path.split('/');
+  const [, repo] = path.split('/');
 
   try {
-    const { data } = await axios.get<RepoResponse>(`https://api.github.com/repos/${owner}/${repo}`);
+    const { data } = await axios.get<RepoResponse>(`https://api.github.com/repos/${path}`);
     return {
       title: data.name,
       body: data.description ?? 'No description available.',
-      photo: data.owner?.avatar_url ?? 'https://via.placeholder.com/300x200',
+      photo: repoImages[repo] ?? 'https://via.placeholder.com/300x200',
       link: repoUrl
     };
   } catch (error) {
@@ -39,7 +49,7 @@ async function fetchRepo(repoUrl: string): Promise<Project> {
     return {
       title: repo,
       body: 'Unable to load repository details.',
-      photo: 'https://via.placeholder.com/300x200',
+      photo: repoImages[repo] ?? 'https://via.placeholder.com/300x200',
       link: repoUrl
     };
   }

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -16,10 +16,14 @@ export const useSetLanguage = () => {
 };
 
 export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [language, setLanguage] = useState<Language>('en');
+  const [language, setLanguage] = useState<Language>(() => {
+    const stored = localStorage.getItem('language') as Language | null;
+    return stored ?? 'en';
+  });
 
   useEffect(() => {
     void i18n.changeLanguage(language);
+    localStorage.setItem('language', language);
   }, [language]);
 
   return (

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+declare module '*.jpg';
+declare module 'bootstrap';


### PR DESCRIPTION
## Summary
- show language options with emoji flags and persist chosen language
- fix contact form toast to reset on success and display at top center
- use local project images and expand projects section to viewport width

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd213ac2c48332b62e9b6a22405310