### PR TITLE
Fix language selector and unify project image sizes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^30.0.0",
         "@types/react": "^18.2.14",
         "@types/react-dom": "^18.2.6",
@@ -3928,6 +3929,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.6",

--- a/src/components/Navbar/Navbar.test.tsx
+++ b/src/components/Navbar/Navbar.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Navbar from './Navbar';
+import { ThemeProvider } from '../../context/ThemeContext';
+import { LanguageProvider } from '../../context/LanguageContext';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}));
+
+jest.mock('../../i18n', () => ({
+  __esModule: true,
+  default: { changeLanguage: jest.fn() }
+}));
+
+describe('Navbar language selector', () => {
+  it('updates language flag when a new language is selected', async () => {
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider>
+        <LanguageProvider>
+          <Navbar />
+        </LanguageProvider>
+      </ThemeProvider>
+    );
+
+    const toggle = screen.getByTestId('lang-toggle');
+    expect(toggle).toHaveTextContent('🇺🇸');
+
+    await user.click(toggle);
+    const spanish = screen.getByRole('button', { name: '🇪🇸' });
+    await user.click(spanish);
+
+    expect(toggle).toHaveTextContent('🇪🇸');
+  });
+});

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -93,6 +93,8 @@ const Navbar: React.FC = () => {
             </li>
             <li className="nav-item dropdown lang-dropdown w-lg-auto">
               <button
+                type="button"
+                data-testid="lang-toggle"
                 className={`btn btn-${isDarkTheme ? 'light' : 'dark'} w-100 w-lg-auto dropdown-toggle my-1 my-lg-0`}
                 data-bs-toggle="dropdown"
                 aria-expanded="false"
@@ -102,7 +104,11 @@ const Navbar: React.FC = () => {
               <ul className="dropdown-menu dropdown-menu-end">
                 {languages.map(lang => (
                   <li key={lang}>
-                    <button className="dropdown-item text-center" onClick={() => setLanguage(lang)}>
+                    <button
+                      type="button"
+                      className="dropdown-item text-center"
+                      onClick={() => setLanguage(lang)}
+                    >
                       {languageFlags[lang]}
                     </button>
                   </li>

--- a/src/components/Projects/Projects.css
+++ b/src/components/Projects/Projects.css
@@ -12,3 +12,9 @@
   z-index: 0;
 }
 
+.card-img-top {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+}
+


### PR DESCRIPTION
## Summary
- ensure language selector buttons explicitly declare type and expose a test id
- keep project thumbnails uniform with consistent dimensions
- cover language dropdown in Navbar with a user interaction test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd267f55248332a49a584e49f95269