### PR TITLE
Fix language dropdown and standardize project images

### DIFF
--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -8,5 +8,6 @@ nav.navbar {
 
 .lang-dropdown .dropdown-menu {
   min-width: 4rem;
+  z-index: 1100;
 }
 

--- a/src/components/Navbar/Navbar.test.tsx
+++ b/src/components/Navbar/Navbar.test.tsx
@@ -15,7 +15,14 @@ jest.mock('../../i18n', () => ({
 }));
 
 describe('Navbar language selector', () => {
-  it('updates language flag when a new language is selected', async () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it.each([
+    ['🇪🇸'],
+    ['🇩🇪']
+  ])('updates language flag when %s is selected', async flag => {
     const user = userEvent.setup();
     render(
       <ThemeProvider>
@@ -29,9 +36,9 @@ describe('Navbar language selector', () => {
     expect(toggle).toHaveTextContent('🇺🇸');
 
     await user.click(toggle);
-    const spanish = screen.getByRole('button', { name: '🇪🇸' });
-    await user.click(spanish);
+    const option = screen.getByRole('button', { name: flag });
+    await user.click(option);
 
-    expect(toggle).toHaveTextContent('🇪🇸');
+    expect(toggle).toHaveTextContent(flag);
   });
 });

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -24,6 +24,9 @@ const Navbar: React.FC = () => {
   const [hidden, setHidden] = useState(false);
   const lastScrollY = useRef(0);
 
+  const [showLangMenu, setShowLangMenu] = useState(false);
+  const dropdownRef = useRef<HTMLLIElement>(null);
+
   useEffect(() => {
     const handleScroll = () => {
       const currentY = window.scrollY;
@@ -38,6 +41,22 @@ const Navbar: React.FC = () => {
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setShowLangMenu(false);
+      }
+    };
+    document.addEventListener('click', handleClickOutside);
+    return () => document.removeEventListener('click', handleClickOutside);
+  }, []);
+
+  const toggleLangMenu = () => setShowLangMenu(prev => !prev);
+  const handleLanguageChange = (lang: Language) => {
+    setLanguage(lang);
+    setShowLangMenu(false);
+  };
 
   return (
     <nav
@@ -91,23 +110,23 @@ const Navbar: React.FC = () => {
                 {t('nav.toggleTheme')}
               </button>
             </li>
-            <li className="nav-item dropdown lang-dropdown w-lg-auto">
+            <li className="nav-item dropdown lang-dropdown w-lg-auto" ref={dropdownRef}>
               <button
                 type="button"
                 data-testid="lang-toggle"
                 className={`btn btn-${isDarkTheme ? 'light' : 'dark'} w-100 w-lg-auto dropdown-toggle my-1 my-lg-0`}
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
+                onClick={toggleLangMenu}
+                aria-expanded={showLangMenu}
               >
                 {languageFlags[language]}
               </button>
-              <ul className="dropdown-menu dropdown-menu-end">
+              <ul className={`dropdown-menu dropdown-menu-end ${showLangMenu ? 'show' : ''}`}>
                 {languages.map(lang => (
                   <li key={lang}>
                     <button
                       type="button"
                       className="dropdown-item text-center"
-                      onClick={() => setLanguage(lang)}
+                      onClick={() => handleLanguageChange(lang)}
                     >
                       {languageFlags[lang]}
                     </button>

--- a/src/components/Projects/Projects.css
+++ b/src/components/Projects/Projects.css
@@ -13,8 +13,9 @@
 }
 
 .card-img-top {
-  width: 100%;
-  height: 200px;
+  width: 400px;
+  height: 400px;
   object-fit: cover;
+  margin: 0 auto;
 }
 


### PR DESCRIPTION
## Summary
- manage language dropdown with React state and ensure visibility
- set project card images to 400x400
- test language selection for multiple options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be4591a78083329b8d93bc71b99724