### PR TITLE
Improve landing page responsiveness

### DIFF
--- a/src/components/LandingPage/LandingPage.css
+++ b/src/components/LandingPage/LandingPage.css
@@ -1,6 +1,5 @@
 
 .landingPage {
-    height: 100vh;
     width: 100%;
     background-color: var(--landing-bg);
 }
@@ -13,12 +12,9 @@
 
 .landingPage p {
     color: var(--text-color);
-    font-size: 24px;
     margin-bottom: 10px;
 }
 
 .landingPage h1 {
     color: var(--text-color);
-    font-size: 36px;
-    max-width: 50%;
 }

--- a/src/components/LandingPage/LandingPage.tsx
+++ b/src/components/LandingPage/LandingPage.tsx
@@ -6,12 +6,12 @@ import { useTranslation } from 'react-i18next';
 const LandingPage: React.FC = () => {
   const { t } = useTranslation();
   return (
-    <div className='landingPage d-flex flex-column align-items-center justify-content-center'>
+    <div className='landingPage d-flex flex-column align-items-center justify-content-center min-vh-100 py-4'>
       <div className="d-flex flex-column align-items-center mb-3">
         <img src={photo} alt="My Photo" className="foto" />
       </div>
-      <h1 className='text-center'>{t('greeting')}</h1>
-      <p className='text-center fs-4 ps-5 pe-5'>{t('description')}</p>
+      <h1 className='text-center fs-2'>{t('greeting')}</h1>
+      <p className='text-center fs-4 px-5'>{t('description')}</p>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- replace bespoke height and padding with Bootstrap `min-vh-100` and `py-4`
- rely on Bootstrap font-size utilities for heading and paragraph

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bec76b8fe0833280c1cc37c4e7abda