### PR TITLE
feat: add responsive navbar toggle

### DIFF
--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -11,3 +11,8 @@ nav.navbar {
   z-index: 1100;
 }
 
+.nav-btn {
+  min-width: 9rem;
+  white-space: nowrap;
+}
+

--- a/src/components/Navbar/Navbar.test.tsx
+++ b/src/components/Navbar/Navbar.test.tsx
@@ -41,4 +41,28 @@ describe('Navbar language selector', () => {
 
     expect(toggle).toHaveTextContent(flag);
   });
+
+  it('toggles menu visibility with navbar toggler and closes after link click', async () => {
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider>
+        <LanguageProvider>
+          <Navbar />
+        </LanguageProvider>
+      </ThemeProvider>
+    );
+
+    const toggler = screen.getByLabelText(/toggle navigation/i);
+    const menu = document.getElementById('navbarNav');
+
+    expect(menu).toHaveClass('collapse');
+
+    await user.click(toggler);
+    expect(menu).toHaveClass('show');
+
+    const firstLink = screen.getByRole('link', { name: 'nav.projects' });
+    await user.click(firstLink);
+
+    expect(menu).toHaveClass('collapse');
+  });
 });

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -26,6 +26,7 @@ const Navbar: React.FC = () => {
 
   const [showLangMenu, setShowLangMenu] = useState(false);
   const dropdownRef = useRef<HTMLLIElement>(null);
+  const [navOpen, setNavOpen] = useState(false);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -56,6 +57,7 @@ const Navbar: React.FC = () => {
   const handleLanguageChange = (lang: Language) => {
     setLanguage(lang);
     setShowLangMenu(false);
+    setNavOpen(false);
   };
 
   return (
@@ -81,22 +83,21 @@ const Navbar: React.FC = () => {
         <button
           className="navbar-toggler"
           type="button"
-          data-bs-toggle="collapse"
-          data-bs-target="#navbarNav"
-          aria-controls="navbarNav"
-          aria-expanded="false"
+          onClick={() => setNavOpen(prev => !prev)}
+          aria-expanded={navOpen}
           aria-label="Toggle navigation"
         >
           <span className="navbar-toggler-icon"></span>
         </button>
 
-        <div className="collapse navbar-collapse justify-content-end" id="navbarNav">
+        <div className={`navbar-collapse ${navOpen ? 'show' : 'collapse'} justify-content-end`} id="navbarNav">
           <ul className="navbar-nav mb-0 align-items-lg-center d-flex gap-2">
             {InnerLinks.map((link, index) => (
               <li key={index} className="nav-item">
                 <a
                   href={link.url}
                   className={`btn btn-${isDarkTheme ? 'light' : 'dark'} w-100 w-lg-auto my-1 my-lg-0`}
+                  onClick={() => setNavOpen(false)}
                 >
                   {t(`nav.${link.key}`)}
                 </a>
@@ -105,7 +106,7 @@ const Navbar: React.FC = () => {
             <li className="nav-item">
               <button
                 className={`btn btn-${isDarkTheme ? 'light' : 'dark'} w-100 w-lg-auto my-1 my-lg-0`}
-                onClick={toggleTheme}
+                onClick={() => { toggleTheme(); setNavOpen(false); }}
               >
                 {t('nav.toggleTheme')}
               </button>

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -96,7 +96,7 @@ const Navbar: React.FC = () => {
               <li key={index} className="nav-item">
                 <a
                   href={link.url}
-                  className={`btn btn-${isDarkTheme ? 'light' : 'dark'} w-100 w-lg-auto my-1 my-lg-0`}
+                  className={`btn btn-${isDarkTheme ? 'light' : 'dark'} w-100 w-lg-auto my-1 my-lg-0 nav-btn`}
                   onClick={() => setNavOpen(false)}
                 >
                   {t(`nav.${link.key}`)}
@@ -105,8 +105,11 @@ const Navbar: React.FC = () => {
             ))}
             <li className="nav-item">
               <button
-                className={`btn btn-${isDarkTheme ? 'light' : 'dark'} w-100 w-lg-auto my-1 my-lg-0`}
-                onClick={() => { toggleTheme(); setNavOpen(false); }}
+                className={`btn btn-${isDarkTheme ? 'light' : 'dark'} w-100 w-lg-auto my-1 my-lg-0 nav-btn`}
+                onClick={() => {
+                  toggleTheme();
+                  setNavOpen(false);
+                }}
               >
                 {t('nav.toggleTheme')}
               </button>
@@ -115,7 +118,7 @@ const Navbar: React.FC = () => {
               <button
                 type="button"
                 data-testid="lang-toggle"
-                className={`btn btn-${isDarkTheme ? 'light' : 'dark'} w-100 w-lg-auto dropdown-toggle my-1 my-lg-0`}
+                className={`btn btn-${isDarkTheme ? 'light' : 'dark'} w-100 w-lg-auto dropdown-toggle my-1 my-lg-0 nav-btn`}
                 onClick={toggleLangMenu}
                 aria-expanded={showLangMenu}
               >
@@ -137,9 +140,9 @@ const Navbar: React.FC = () => {
             </li>
           </ul>
         </div>
-        </div>
-      </nav>
-    );
-  };
+      </div>
+    </nav>
+  );
+};
 
 export default Navbar;


### PR DESCRIPTION
## Summary
- add stateful mobile navbar toggle
- close menu after link selection
- test navbar collapsible behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bec7724aa88332a49384210ba4a207