### PR TITLE
Add fifth social link and contact form validation

### DIFF
--- a/src/components/ContactForm/ContactForm.test.tsx
+++ b/src/components/ContactForm/ContactForm.test.tsx
@@ -5,6 +5,8 @@ import ContactForm from './ContactForm';
 import { ThemeProvider } from '../../context/ThemeContext';
 import { LanguageProvider } from '../../context/LanguageContext';
 
+void React;
+
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key })
 }));

--- a/src/components/ContactForm/ContactForm.test.tsx
+++ b/src/components/ContactForm/ContactForm.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ContactForm from './ContactForm';
+import { ThemeProvider } from '../../context/ThemeContext';
+import { LanguageProvider } from '../../context/LanguageContext';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}));
+
+jest.mock('bootstrap', () => ({
+  Toast: jest.fn().mockImplementation(() => ({ show: jest.fn() }))
+}));
+
+jest.mock('../../i18n', () => ({
+  __esModule: true,
+  default: { changeLanguage: jest.fn() }
+}));
+
+const renderForm = () =>
+  render(
+    <ThemeProvider>
+      <LanguageProvider>
+        <ContactForm />
+      </LanguageProvider>
+    </ThemeProvider>
+  );
+
+test('shows error when message is shorter than 25 characters', async () => {
+  const user = userEvent.setup();
+  renderForm();
+
+  await user.type(screen.getByLabelText('contact.name'), 'John');
+  await user.type(screen.getByLabelText('contact.email'), 'john@example.com');
+  await user.type(screen.getByLabelText('contact.message'), 'too short');
+  await user.click(screen.getByRole('button', { name: 'contact.submit' }));
+
+  expect(screen.getByText('contact.errors.messageLength')).toBeInTheDocument();
+});
+
+test('displays spinner during form submission', async () => {
+  jest.useFakeTimers();
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  renderForm();
+
+  await user.type(screen.getByLabelText('contact.name'), 'John');
+  await user.type(screen.getByLabelText('contact.email'), 'john@example.com');
+  await user.type(
+    screen.getByLabelText('contact.message'),
+    'This is a sufficiently long message with more than twenty five characters.'
+  );
+
+  const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.6);
+  await user.click(screen.getByRole('button', { name: 'contact.submit' }));
+
+  expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+  await act(async () => {
+    jest.runAllTimers();
+  });
+  expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
+  randomSpy.mockRestore();
+  jest.useRealTimers();
+});

--- a/src/components/ContactForm/ContactForm.tsx
+++ b/src/components/ContactForm/ContactForm.tsx
@@ -13,6 +13,7 @@ const ContactForm: React.FC = () => {
   const toastRef = useRef<HTMLDivElement>(null);
   const [toastMessage, setToastMessage] = useState('');
   const [toastType, setToastType] = useState<'success' | 'danger'>('success');
+  const [submitting, setSubmitting] = useState(false);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const { id, value } = e.target;
@@ -23,7 +24,11 @@ const ContactForm: React.FC = () => {
     const newErrors: { [key: string]: string } = {};
     if (!form.name.trim()) newErrors.name = t('contact.errors.name');
     if (!form.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email)) newErrors.email = t('contact.errors.email');
-    if (!form.message.trim()) newErrors.message = t('contact.errors.message');
+    if (!form.message.trim()) {
+      newErrors.message = t('contact.errors.message');
+    } else if (form.message.trim().length < 25) {
+      newErrors.message = t('contact.errors.messageLength');
+    }
     return newErrors;
   };
 
@@ -32,19 +37,23 @@ const ContactForm: React.FC = () => {
     const newErrors = validate();
     setErrors(newErrors);
     if (Object.keys(newErrors).length === 0) {
-      const success = Math.random() > 0.5;
-      if (success) {
-        setToastMessage(`Thank you ${form.name}, your message was sent successfully!`);
-        setToastType('success');
-        setForm({ name: '', email: '', type: 'hireMe', message: '' });
-      } else {
-        setToastMessage('There was an error sending your message.');
-        setToastType('danger');
-      }
-      if (toastRef.current) {
-        const toast = new Toast(toastRef.current);
-        toast.show();
-      }
+      setSubmitting(true);
+      setTimeout(() => {
+        const success = Math.random() > 0.5;
+        if (success) {
+          setToastMessage(`Thank you ${form.name}, your message was sent successfully!`);
+          setToastType('success');
+          setForm({ name: '', email: '', type: 'hireMe', message: '' });
+        } else {
+          setToastMessage('There was an error sending your message.');
+          setToastType('danger');
+        }
+        setSubmitting(false);
+        if (toastRef.current) {
+          const toast = new Toast(toastRef.current);
+          toast.show();
+        }
+      }, 1000);
     }
   };
 
@@ -71,8 +80,17 @@ const ContactForm: React.FC = () => {
         <textarea id='message' className='form-control' value={form.message} onChange={handleChange}></textarea>
         {errors.message && <div className='text-danger'>{errors.message}</div>}
 
-        <button type='submit' className={`btn btn-${isDarkTheme ? 'light' : 'dark'} mt-2`}>
-          {t('contact.submit')}
+        <button type='submit' className={`btn btn-${isDarkTheme ? 'light' : 'dark'} mt-2`} disabled={submitting}>
+          {submitting ? (
+            <span
+              className="spinner-border spinner-border-sm"
+              role="status"
+              aria-hidden="true"
+              data-testid="loading-spinner"
+            ></span>
+          ) : (
+            t('contact.submit')
+          )}
         </button>
       </form>
       <div className='position-fixed top-0 start-50 translate-middle-x p-3' style={{ zIndex: 11 }}>

--- a/src/components/Navbar/Icons.ts
+++ b/src/components/Navbar/Icons.ts
@@ -1,6 +1,6 @@
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { faEnvelope } from '@fortawesome/free-solid-svg-icons';
-import { faGithub, faLinkedin, faStackOverflow } from '@fortawesome/free-brands-svg-icons';
+import { faGithub, faLinkedin, faStackOverflow, faTwitter } from '@fortawesome/free-brands-svg-icons';
 
 interface SocialIcon {
   icon: IconDefinition;
@@ -19,6 +19,10 @@ const Icons: SocialIcon[] = [
   {
     icon: faStackOverflow,
     url: "https://stackoverflow.com/users/22202650/seta1609",
+  },
+  {
+    icon: faTwitter,
+    url: "https://twitter.com/SETA1609",
   },
   {
     icon: faEnvelope,

--- a/src/components/Navbar/Navbar.test.tsx
+++ b/src/components/Navbar/Navbar.test.tsx
@@ -16,6 +16,26 @@ jest.mock('../../i18n', () => ({
   default: { changeLanguage: jest.fn() }
 }));
 
+describe('Navbar social links', () => {
+  it('renders five external social links that open in a new tab', () => {
+    render(
+      <ThemeProvider>
+        <LanguageProvider>
+          <Navbar />
+        </LanguageProvider>
+      </ThemeProvider>
+    );
+
+    const externalLinks = screen
+      .getAllByRole('link')
+      .filter(link => link.getAttribute('target') === '_blank');
+    expect(externalLinks).toHaveLength(5);
+    externalLinks.forEach(link => {
+      expect(link).toHaveAttribute('rel', 'noreferrer');
+    });
+  });
+});
+
 describe('Navbar language selector', () => {
   beforeEach(() => {
     localStorage.clear();

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -29,7 +29,8 @@
     "errors": {
       "name": "Name ist erforderlich",
       "email": "Gültige E-Mail ist erforderlich",
-      "message": "Nachricht ist erforderlich"
+      "message": "Nachricht ist erforderlich",
+      "messageLength": "Muss mindestens 25 Zeichen lang sein"
     }
   },
   "footer": "Erstellt von Sebastian Tamayo",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -29,7 +29,8 @@
     "errors": {
       "name": "Name is required",
       "email": "Valid email is required",
-      "message": "Message is required"
+      "message": "Message is required",
+      "messageLength": "Must be at least 25 characters"
     }
   },
   "footer": "Made by Sebastian Tamayo",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -29,7 +29,8 @@
       "errors": {
         "name": "Nombre es obligatorio",
         "email": "Correo válido es obligatorio",
-        "message": "Mensaje es obligatorio"
+        "message": "Mensaje es obligatorio",
+        "messageLength": "Debe tener al menos 25 caracteres"
       }
     },
     "footer": "Hecho por Sebastian Tamayo",


### PR DESCRIPTION
## Summary
- add Twitter link so header shows five social icons
- validate contact form message length and show loading spinner on submit
- add tests for social links, message validation, and spinner display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bef0e9b7888332afe64d78ff4c9cf6