### PR TITLE
Add validation feedback for contact form

### DIFF
--- a/src/components/ContactForm/ContactForm.test.tsx
+++ b/src/components/ContactForm/ContactForm.test.tsx
@@ -5,20 +5,10 @@ import ContactForm from './ContactForm';
 import { ThemeProvider } from '../../context/ThemeContext';
 import { LanguageProvider } from '../../context/LanguageContext';
 
-void React;
-
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key })
-}));
-
 jest.mock('bootstrap', () => ({
   Toast: jest.fn().mockImplementation(() => ({ show: jest.fn() }))
 }));
 
-jest.mock('../../i18n', () => ({
-  __esModule: true,
-  default: { changeLanguage: jest.fn() }
-}));
 
 const renderForm = () =>
   render(
@@ -29,16 +19,65 @@ const renderForm = () =>
     </ThemeProvider>
   );
 
-test('shows error when message is shorter than 25 characters', async () => {
+test('shows required message for Name on blur', async () => {
   const user = userEvent.setup();
   renderForm();
+  const nameInput = screen.getByLabelText('Name');
+  await user.click(nameInput);
+  await user.tab();
+  expect(nameInput).toHaveClass('is-invalid');
+  expect(screen.getByText('Required')).toBeInTheDocument();
+});
 
-  await user.type(screen.getByLabelText('contact.name'), 'John');
-  await user.type(screen.getByLabelText('contact.email'), 'john@example.com');
-  await user.type(screen.getByLabelText('contact.message'), 'too short');
-  await user.click(screen.getByRole('button', { name: 'contact.submit' }));
+test('shows required message for Email on blur when empty', async () => {
+  const user = userEvent.setup();
+  renderForm();
+  const emailInput = screen.getByLabelText('Email');
+  await user.click(emailInput);
+  await user.tab();
+  expect(emailInput).toHaveClass('is-invalid');
+  expect(screen.getByText('Required')).toBeInTheDocument();
+});
 
-  expect(screen.getByText('contact.errors.messageLength')).toBeInTheDocument();
+test('shows invalid email message for malformed Email input', async () => {
+  const user = userEvent.setup();
+  renderForm();
+  const emailInput = screen.getByLabelText('Email');
+  await user.type(emailInput, 'invalid');
+  await user.tab();
+  expect(emailInput).toHaveClass('is-invalid');
+  expect(screen.getByText('Invalid email address')).toBeInTheDocument();
+});
+
+test('shows required message for message textarea on blur', async () => {
+  const user = userEvent.setup();
+  renderForm();
+  const messageInput = screen.getByLabelText('Your message');
+  await user.click(messageInput);
+  await user.tab();
+  expect(messageInput).toHaveClass('is-invalid');
+  expect(screen.getByText('Required')).toBeInTheDocument();
+});
+
+test('shows length error for short message', async () => {
+  const user = userEvent.setup();
+  renderForm();
+  const messageInput = screen.getByLabelText('Your message');
+  await user.type(messageInput, 'short message');
+  await user.tab();
+  expect(messageInput).toHaveClass('is-invalid');
+  expect(screen.getByText('Must be at least 25 characters')).toBeInTheDocument();
+});
+
+test('submit without values shows required messages for all fields', async () => {
+  const user = userEvent.setup();
+  renderForm();
+  await user.click(screen.getByRole('button', { name: 'Submit' }));
+  const requiredMessages = screen.getAllByText('Required');
+  expect(requiredMessages).toHaveLength(3);
+  expect(screen.getByLabelText('Name')).toHaveClass('is-invalid');
+  expect(screen.getByLabelText('Email')).toHaveClass('is-invalid');
+  expect(screen.getByLabelText('Your message')).toHaveClass('is-invalid');
 });
 
 test('displays spinner during form submission', async () => {
@@ -46,15 +85,15 @@ test('displays spinner during form submission', async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
   renderForm();
 
-  await user.type(screen.getByLabelText('contact.name'), 'John');
-  await user.type(screen.getByLabelText('contact.email'), 'john@example.com');
+  await user.type(screen.getByLabelText('Name'), 'John');
+  await user.type(screen.getByLabelText('Email'), 'john@example.com');
   await user.type(
-    screen.getByLabelText('contact.message'),
+    screen.getByLabelText('Your message'),
     'This is a sufficiently long message with more than twenty five characters.'
   );
 
   const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.6);
-  await user.click(screen.getByRole('button', { name: 'contact.submit' }));
+  await user.click(screen.getByRole('button', { name: 'Submit' }));
 
   expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
   await act(async () => {
@@ -64,3 +103,4 @@ test('displays spinner during form submission', async () => {
   randomSpy.mockRestore();
   jest.useRealTimers();
 });
+

--- a/src/components/ContactForm/ContactForm.test.tsx
+++ b/src/components/ContactForm/ContactForm.test.tsx
@@ -5,6 +5,8 @@ import ContactForm from './ContactForm';
 import { ThemeProvider } from '../../context/ThemeContext';
 import { LanguageProvider } from '../../context/LanguageContext';
 
+void React;
+
 jest.mock('bootstrap', () => ({
   Toast: jest.fn().mockImplementation(() => ({ show: jest.fn() }))
 }));

--- a/src/components/ContactForm/ContactForm.tsx
+++ b/src/components/ContactForm/ContactForm.tsx
@@ -8,7 +8,14 @@ const ContactForm: React.FC = () => {
   const { t } = useTranslation();
   const isDarkTheme = useTheme();
 
-  const [form, setForm] = useState({ name: '', email: '', type: 'hireMe', message: '' });
+  interface FormState {
+    name: string;
+    email: string;
+    type: 'hireMe' | 'openSource' | 'other';
+    message: string;
+  }
+
+  const [form, setForm] = useState<FormState>({ name: '', email: '', type: 'hireMe', message: '' });
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
   const toastRef = useRef<HTMLDivElement>(null);
   const [toastMessage, setToastMessage] = useState('');
@@ -41,9 +48,9 @@ const ContactForm: React.FC = () => {
 
   const validate = () => {
     const newErrors: { [key: string]: string } = {};
-    ['name', 'email', 'message'].forEach(field => {
-      const value = (form as any)[field];
-      const error = validateField(field, value);
+    const fields: Array<keyof FormState> = ['name', 'email', 'message'];
+    fields.forEach(field => {
+      const error = validateField(field, form[field]);
       if (error) newErrors[field] = error;
     });
     return newErrors;

--- a/src/components/ContactForm/ContactForm.tsx
+++ b/src/components/ContactForm/ContactForm.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useRef } from 'react';
+import React, { useRef } from 'react';
 import './ContactForm.css';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '../../context/ThemeContext';
 import { Toast } from 'bootstrap';
+import { useFormik } from 'formik';
 
 const ContactForm: React.FC = () => {
   const { t } = useTranslation();
@@ -15,59 +16,34 @@ const ContactForm: React.FC = () => {
     message: string;
   }
 
-  const [form, setForm] = useState<FormState>({ name: '', email: '', type: 'hireMe', message: '' });
-  const [errors, setErrors] = useState<{ [key: string]: string }>({});
   const toastRef = useRef<HTMLDivElement>(null);
-  const [toastMessage, setToastMessage] = useState('');
-  const [toastType, setToastType] = useState<'success' | 'danger'>('success');
-  const [submitting, setSubmitting] = useState(false);
+  const [toastMessage, setToastMessage] = React.useState('');
+  const [toastType, setToastType] = React.useState<'success' | 'danger'>('success');
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
-    const { id, value } = e.target;
-    setForm(prev => ({ ...prev, [id]: value }));
-    setErrors(prev => ({ ...prev, [id]: '' }));
-  };
-
-  const validateField = (id: string, value: string) => {
-    if (id === 'name' && !value.trim()) return t('contact.errors.required');
-    if (id === 'email') {
-      if (!value.trim()) return t('contact.errors.required');
-      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) return t('contact.errors.invalidEmail');
-    }
-    if (id === 'message') {
-      if (!value.trim()) return t('contact.errors.required');
-      if (value.trim().length < 25) return t('contact.errors.messageLength');
-    }
-    return '';
-  };
-
-  const handleBlur = (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
-    const { id, value } = e.target;
-    setErrors(prev => ({ ...prev, [id]: validateField(id, value) }));
-  };
-
-  const validate = () => {
-    const newErrors: { [key: string]: string } = {};
-    const fields: Array<keyof FormState> = ['name', 'email', 'message'];
-    fields.forEach(field => {
-      const error = validateField(field, form[field]);
-      if (error) newErrors[field] = error;
-    });
-    return newErrors;
-  };
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    const newErrors = validate();
-    setErrors(newErrors);
-    if (Object.keys(newErrors).length === 0) {
-      setSubmitting(true);
+  const formik = useFormik<FormState>({
+    initialValues: { name: '', email: '', type: 'hireMe', message: '' },
+    validate: values => {
+      const errs: { [key: string]: string } = {};
+      if (!values.name.trim()) errs.name = t('contact.errors.required');
+      if (!values.email.trim()) {
+        errs.email = t('contact.errors.required');
+      } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(values.email)) {
+        errs.email = t('contact.errors.invalidEmail');
+      }
+      if (!values.message.trim()) {
+        errs.message = t('contact.errors.required');
+      } else if (values.message.trim().length < 25) {
+        errs.message = t('contact.errors.messageLength');
+      }
+      return errs;
+    },
+    onSubmit: (values, { setSubmitting, resetForm }) => {
       setTimeout(() => {
         const success = Math.random() > 0.5;
         if (success) {
-          setToastMessage(`Thank you ${form.name}, your message was sent successfully!`);
+          setToastMessage(`Thank you ${values.name}, your message was sent successfully!`);
           setToastType('success');
-          setForm({ name: '', email: '', type: 'hireMe', message: '' });
+          resetForm();
         } else {
           setToastMessage('There was an error sending your message.');
           setToastType('danger');
@@ -78,37 +54,49 @@ const ContactForm: React.FC = () => {
           toast.show();
         }
       }, 1000);
-    }
-  };
+    },
+  });
 
   return (
     <div className='form d-flex justify-content-center align-items-center text-center' id='contact'>
-      <form className='d-flex flex-column gap-3' onSubmit={handleSubmit} noValidate>
+      <form className='d-flex flex-column gap-3' onSubmit={formik.handleSubmit} noValidate>
         <div className='fs-1'>{t('contact.title')}</div>
         <label htmlFor='name' className='form-label fw-bold mb-1'>{t('contact.name')}</label>
         <input
           id='name'
+          name='name'
           type='text'
-          className={`form-control ${errors.name ? 'is-invalid' : ''}`}
-          value={form.name}
-          onChange={handleChange}
-          onBlur={handleBlur}
+          className={`form-control ${formik.touched.name && formik.errors.name ? 'is-invalid' : ''}`}
+          value={formik.values.name}
+          onChange={formik.handleChange}
+          onBlur={formik.handleBlur}
         />
-        {errors.name && <div className='text-danger'>{errors.name}</div>}
+        {formik.touched.name && formik.errors.name && (
+          <div className='text-danger'>{formik.errors.name}</div>
+        )}
 
         <label htmlFor='email' className='form-label fw-bold mb-1'>{t('contact.email')}</label>
         <input
           id='email'
+          name='email'
           type='email'
-          className={`form-control ${errors.email ? 'is-invalid' : ''}`}
-          value={form.email}
-          onChange={handleChange}
-          onBlur={handleBlur}
+          className={`form-control ${formik.touched.email && formik.errors.email ? 'is-invalid' : ''}`}
+          value={formik.values.email}
+          onChange={formik.handleChange}
+          onBlur={formik.handleBlur}
         />
-        {errors.email && <div className='text-danger'>{errors.email}</div>}
+        {formik.touched.email && formik.errors.email && (
+          <div className='text-danger'>{formik.errors.email}</div>
+        )}
 
         <label htmlFor='type' className='form-label fw-bold mb-1'>{t('contact.type.label')}</label>
-        <select id='type' name='type' className='form-select' value={form.type} onChange={handleChange}>
+        <select
+          id='type'
+          name='type'
+          className='form-select'
+          value={formik.values.type}
+          onChange={formik.handleChange}
+        >
           <option value="hireMe">{t('contact.type.hireMe')}</option>
           <option value="openSource">{t('contact.type.openSource')}</option>
           <option value="other">{t('contact.type.other')}</option>
@@ -117,15 +105,22 @@ const ContactForm: React.FC = () => {
         <label htmlFor='message' className='form-label fw-bold mb-1'>{t('contact.message')}</label>
         <textarea
           id='message'
-          className={`form-control ${errors.message ? 'is-invalid' : ''}`}
-          value={form.message}
-          onChange={handleChange}
-          onBlur={handleBlur}
+          name='message'
+          className={`form-control ${formik.touched.message && formik.errors.message ? 'is-invalid' : ''}`}
+          value={formik.values.message}
+          onChange={formik.handleChange}
+          onBlur={formik.handleBlur}
         ></textarea>
-        {errors.message && <div className='text-danger'>{errors.message}</div>}
+        {formik.touched.message && formik.errors.message && (
+          <div className='text-danger'>{formik.errors.message}</div>
+        )}
 
-        <button type='submit' className={`btn btn-${isDarkTheme ? 'light' : 'dark'} mt-2`} disabled={submitting}>
-          {submitting ? (
+        <button
+          type='submit'
+          className={`btn btn-${isDarkTheme ? 'light' : 'dark'} mt-2`}
+          disabled={formik.isSubmitting}
+        >
+          {formik.isSubmitting ? (
             <span
               className="spinner-border spinner-border-sm"
               role="status"

--- a/src/components/ContactForm/ContactForm.tsx
+++ b/src/components/ContactForm/ContactForm.tsx
@@ -18,17 +18,34 @@ const ContactForm: React.FC = () => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const { id, value } = e.target;
     setForm(prev => ({ ...prev, [id]: value }));
+    setErrors(prev => ({ ...prev, [id]: '' }));
+  };
+
+  const validateField = (id: string, value: string) => {
+    if (id === 'name' && !value.trim()) return t('contact.errors.required');
+    if (id === 'email') {
+      if (!value.trim()) return t('contact.errors.required');
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) return t('contact.errors.invalidEmail');
+    }
+    if (id === 'message') {
+      if (!value.trim()) return t('contact.errors.required');
+      if (value.trim().length < 25) return t('contact.errors.messageLength');
+    }
+    return '';
+  };
+
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    const { id, value } = e.target;
+    setErrors(prev => ({ ...prev, [id]: validateField(id, value) }));
   };
 
   const validate = () => {
     const newErrors: { [key: string]: string } = {};
-    if (!form.name.trim()) newErrors.name = t('contact.errors.name');
-    if (!form.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email)) newErrors.email = t('contact.errors.email');
-    if (!form.message.trim()) {
-      newErrors.message = t('contact.errors.message');
-    } else if (form.message.trim().length < 25) {
-      newErrors.message = t('contact.errors.messageLength');
-    }
+    ['name', 'email', 'message'].forEach(field => {
+      const value = (form as any)[field];
+      const error = validateField(field, value);
+      if (error) newErrors[field] = error;
+    });
     return newErrors;
   };
 
@@ -62,11 +79,25 @@ const ContactForm: React.FC = () => {
       <form className='d-flex flex-column gap-3' onSubmit={handleSubmit} noValidate>
         <div className='fs-1'>{t('contact.title')}</div>
         <label htmlFor='name' className='form-label fw-bold mb-1'>{t('contact.name')}</label>
-        <input id='name' type='text' className='form-control' value={form.name} onChange={handleChange} />
+        <input
+          id='name'
+          type='text'
+          className={`form-control ${errors.name ? 'is-invalid' : ''}`}
+          value={form.name}
+          onChange={handleChange}
+          onBlur={handleBlur}
+        />
         {errors.name && <div className='text-danger'>{errors.name}</div>}
 
         <label htmlFor='email' className='form-label fw-bold mb-1'>{t('contact.email')}</label>
-        <input id='email' type='email' className='form-control' value={form.email} onChange={handleChange} />
+        <input
+          id='email'
+          type='email'
+          className={`form-control ${errors.email ? 'is-invalid' : ''}`}
+          value={form.email}
+          onChange={handleChange}
+          onBlur={handleBlur}
+        />
         {errors.email && <div className='text-danger'>{errors.email}</div>}
 
         <label htmlFor='type' className='form-label fw-bold mb-1'>{t('contact.type.label')}</label>
@@ -77,7 +108,13 @@ const ContactForm: React.FC = () => {
         </select>
 
         <label htmlFor='message' className='form-label fw-bold mb-1'>{t('contact.message')}</label>
-        <textarea id='message' className='form-control' value={form.message} onChange={handleChange}></textarea>
+        <textarea
+          id='message'
+          className={`form-control ${errors.message ? 'is-invalid' : ''}`}
+          value={form.message}
+          onChange={handleChange}
+          onBlur={handleBlur}
+        ></textarea>
         {errors.message && <div className='text-danger'>{errors.message}</div>}
 
         <button type='submit' className={`btn btn-${isDarkTheme ? 'light' : 'dark'} mt-2`} disabled={submitting}>

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -27,9 +27,8 @@
     "message": "Deine Nachricht",
     "submit": "Senden",
     "errors": {
-      "name": "Name ist erforderlich",
-      "email": "Gültige E-Mail ist erforderlich",
-      "message": "Nachricht ist erforderlich",
+      "required": "Erforderlich",
+      "invalidEmail": "Ungültige E-Mail-Adresse",
       "messageLength": "Muss mindestens 25 Zeichen lang sein"
     }
   },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -27,9 +27,8 @@
     "message": "Your message",
     "submit": "Submit",
     "errors": {
-      "name": "Name is required",
-      "email": "Valid email is required",
-      "message": "Message is required",
+      "required": "Required",
+      "invalidEmail": "Invalid email address",
       "messageLength": "Must be at least 25 characters"
     }
   },

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -27,9 +27,8 @@
       "message": "Tu mensaje",
       "submit": "Enviar",
       "errors": {
-        "name": "Nombre es obligatorio",
-        "email": "Correo válido es obligatorio",
-        "message": "Mensaje es obligatorio",
+        "required": "Requerido",
+        "invalidEmail": "Correo electrónico inválido",
         "messageLength": "Debe tener al menos 25 caracteres"
       }
     },


### PR DESCRIPTION
## Summary
- add field-level validation with blur handling and error styling
- update translations with reusable error messages
- cover form validation scenarios with new Jest tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bef66ce7fc833290a7100bfc2b593b